### PR TITLE
feat: Add panTransition prop for customizable animation timing

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -80,6 +80,8 @@ interface Props {
   growTransition?: Transition;
   /** Custom blur transition */
   blurTransition?: Transition;
+  /** Custom pan-to-home transition (stage 2) */
+  panTransition?: Transition;
 
   // ============== Background Customization ==============
   /** Custom canvas background. If not provided, uses DefaultCanvasBackground. */
@@ -117,6 +119,7 @@ const Canvas: FC<Props> = ({
   canvasBoxGradient,
   growTransition,
   blurTransition,
+  panTransition,
   canvasBackground,
   wrapperBackground,
   toolbarConfig,
@@ -225,14 +228,23 @@ const Canvas: FC<Props> = ({
     };
   }, [derivedScale, derivedX, derivedY, animationStage, scale, x, y]);
 
+  // Merge custom panTransition with defaults
+  const effectivePanTransition: Transition = useMemo(() => {
+    if (!panTransition) return STAGE2_TRANSITION;
+    return {
+      ...STAGE2_TRANSITION,
+      ...panTransition,
+    };
+  }, [panTransition]);
+
   // Kick off stage2 (pan to home) when grow completes (introProgress hits 1)
   const startStage2 = useCallback(() => {
     setAnimationStage(1);
 
     Promise.all([
-      animate(x, offsetHomeCoordinates.x, STAGE2_TRANSITION),
-      animate(y, offsetHomeCoordinates.y, STAGE2_TRANSITION),
-      animate(scale, 1, STAGE2_TRANSITION),
+      animate(x, offsetHomeCoordinates.x, effectivePanTransition),
+      animate(y, offsetHomeCoordinates.y, effectivePanTransition),
+      animate(scale, 1, effectivePanTransition),
     ])
       .then(() => {
         setAnimationStage(2);
@@ -241,7 +253,7 @@ const Canvas: FC<Props> = ({
       .catch(() => {
         isIntroAnimatingRef.current = false;
       });
-  }, [offsetHomeCoordinates, x, y, scale]);
+  }, [offsetHomeCoordinates, x, y, scale, effectivePanTransition]);
 
   const viewportRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<HTMLDivElement>(null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,4 +61,5 @@ export type {
   NavbarDisplayMode,
   NavbarButtonConfig,
   NavbarTooltipConfig,
+  AnimationTimingConfig,
 } from "./types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,8 @@
  * Apps should extend these types with their specific enums and constants
  */
 
+import type { Transition } from "framer-motion";
+
 export interface SectionCoordinates {
   x: number;
   y: number;
@@ -151,6 +153,28 @@ export interface NavbarButtonConfig {
   /** Label inline styles */
   labelStyle?: React.CSSProperties;
 }
+
+/**
+ * Animation timing configuration for intro animations.
+ * Re-exports Framer Motion's Transition type for full flexibility.
+ *
+ * @example
+ * // Simple duration-based transition
+ * const timing: AnimationTimingConfig = {
+ *   duration: 1.5,
+ *   delay: 0.5,
+ *   ease: "easeInOut"
+ * };
+ *
+ * @example
+ * // Custom bezier curve
+ * const timing: AnimationTimingConfig = {
+ *   duration: 0.96,
+ *   delay: 3.14,
+ *   ease: [0.35, 0.1, 0.8, 1]
+ * };
+ */
+export type AnimationTimingConfig = Transition;
 
 /**
  * Configuration options for the canvas navbar


### PR DESCRIPTION
## Summary

- Adds a new `panTransition` prop to the Canvas component for customizing the stage 2 (pan-to-home) animation timing
- Creates an `AnimationTimingConfig` type alias that re-exports Framer Motion's `Transition` type for type-safe configuration
- Maintains backwards compatibility - defaults to existing `STAGE2_TRANSITION` when prop is not provided

This completes the animation timing customization story alongside the existing `growTransition` and `blurTransition` props.

## Test plan

- [ ] Verify TypeScript compiles with `npm run type-check`
- [ ] Test that default behavior is unchanged when `panTransition` is not provided
- [ ] Test custom `panTransition` values are applied correctly
- [ ] Verify the `AnimationTimingConfig` type is exported and usable by consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)