### PR TITLE
feat: add navigateToSection to canvas context

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -38,6 +38,7 @@ import {
   TRACKPAD_ZOOM_SENSITIVITY,
   DEFAULT_CANVAS_WIDTH,
   DEFAULT_CANVAS_HEIGHT,
+  RESPONSIVE_ZOOM_MAP,
 } from "../../lib/constants";
 import useWindowDimensions from "../../hooks/useWindowDimensions";
 import Navbar from "./navbar";
@@ -645,6 +646,57 @@ const Canvas: FC<Props> = ({
     [panToOffset, viewportRef]
   );
 
+  // --- navigateToSection: delegates to Navbar when mounted, falls back to basic pan ---
+  const navbarNavigateRef = useRef<((sectionId: string) => void) | null>(null);
+
+  const registerNavbarNavigate = useCallback(
+    (handler: ((sectionId: string) => void) | null) => {
+      navbarNavigateRef.current = handler;
+    },
+    []
+  );
+
+  const navigateToSection = useCallback(
+    (sectionId: string) => {
+      if (navbarNavigateRef.current) {
+        // Navbar is mounted — delegate for full behavior (highlight, pre-render, etc.)
+        navbarNavigateRef.current(sectionId);
+      } else if (navItems) {
+        // Fallback: no navbar, do basic pan
+        const item = navItems.find((i) => i.id === sectionId);
+        if (!item) return;
+
+        setNextTargetSection(sectionId);
+
+        if (item.isHome) {
+          onResetViewAndItems();
+        } else {
+          const zoom = RESPONSIVE_ZOOM_MAP[getScreenSizeEnum(windowWidth)];
+          const panCoords = getSectionPanCoordinates({
+            windowDimensions: { width: windowWidth, height: windowHeight },
+            coords: {
+              x: item.x,
+              y: item.y,
+              width: item.width,
+              height: item.height,
+            },
+            targetZoom: zoom,
+            negative: true,
+          });
+          handlePanToOffset(panCoords, undefined, zoom);
+        }
+      }
+    },
+    [
+      navItems,
+      windowWidth,
+      windowHeight,
+      onResetViewAndItems,
+      handlePanToOffset,
+      setNextTargetSection,
+    ]
+  );
+
   return (
     <CanvasWrapper
       introProgress={introProgress}
@@ -668,6 +720,7 @@ const Canvas: FC<Props> = ({
         animationStage={animationStage}
         nextTargetSection={nextTargetSection}
         setNextTargetSection={setNextTargetSection}
+        navigateToSection={navigateToSection}
       >
         {animationStage >= 2 && (
           <>
@@ -683,6 +736,7 @@ const Canvas: FC<Props> = ({
                 onReset={onResetViewAndItems}
                 items={navItems}
                 config={navbarConfig}
+                onRegisterNavigate={registerNavbarNavigate}
               />
             )}
           </>

--- a/src/components/canvas/navbar/index.tsx
+++ b/src/components/canvas/navbar/index.tsx
@@ -26,6 +26,8 @@ interface NavbarProps {
   items: NavItem[];
   /** Navbar configuration options */
   config?: NavbarConfig;
+  /** Register a handler so external code can trigger navigation via navigateToSection */
+  onRegisterNavigate?: (handler: ((sectionId: string) => void) | null) => void;
 }
 
 const positionStyles: Record<NavbarPosition, React.CSSProperties> = {
@@ -68,6 +70,7 @@ export default function Navbar({
   onReset,
   items,
   config = {},
+  onRegisterNavigate,
 }: NavbarProps) {
   const { x, y, scale, animationStage, setNextTargetSection } =
     useCanvasContext();
@@ -180,6 +183,27 @@ export default function Navbar({
     },
     [panToOffset, onReset, width, height, defaultZoom, setNextTargetSection],
   );
+
+  // Register handlePan for external navigation via navigateToSection
+  const handlePanRef = useRef(handlePan);
+  useEffect(() => {
+    handlePanRef.current = handlePan;
+  }, [handlePan]);
+
+  const itemsRef = useRef(items);
+  useEffect(() => {
+    itemsRef.current = items;
+  }, [items]);
+
+  useEffect(() => {
+    if (!onRegisterNavigate) return;
+    const handler = (sectionId: string) => {
+      const item = itemsRef.current.find((i) => i.id === sectionId);
+      if (item) handlePanRef.current(item);
+    };
+    onRegisterNavigate(handler);
+    return () => onRegisterNavigate(null);
+  }, [onRegisterNavigate]);
 
   // Clean up timers on unmount and pan to home on animation complete
   useEffect(() => {

--- a/src/contexts/CanvasContext.tsx
+++ b/src/contexts/CanvasContext.tsx
@@ -17,6 +17,8 @@ export interface CanvasContextState {
   animationStage: number;
   nextTargetSection: CanvasSection | null; // predictive pre-render target
   setNextTargetSection: (section: CanvasSection | null) => void;
+  /** Navigate to a section by its NavItem id. Pans the canvas and highlights the navbar button. */
+  navigateToSection: (sectionId: string) => void;
 }
 
 const defaultState = {
@@ -32,6 +34,9 @@ const defaultState = {
   nextTargetSection: null,
   setNextTargetSection: () => {
     console.log("setNextTargetSection not set");
+  },
+  navigateToSection: () => {
+    console.log("navigateToSection not set");
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Adds `navigateToSection(sectionId: string)` to `CanvasContext`, accessible via `useCanvasContext()`
- When a Navbar is mounted, delegates to its internal `handlePan` for full behavior (button highlight, predictive pre-render, responsive zoom, debounce)
- Falls back to basic pan/zoom when no Navbar is present
- Uses a registration pattern: Navbar registers its `handlePan` on mount via `onRegisterNavigate`, keeping all Navbar internals encapsulated

## Test plan
- [ ] Call `navigateToSection("sectionId")` from a component inside Canvas — verify it pans to the section and highlights the navbar button
- [ ] Verify navbar button clicks still work as before
- [ ] Verify navigation works when no Navbar is mounted (fallback path)
- [ ] Verify no stale closure issues by navigating after window resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)