### PR TITLE
ci(bench): make bundle budget informational, report deltas on the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,11 @@ jobs:
         id: bundle
         run: |
           set +e
-          npm run --silent bench:bundle:compare -- --skip-build > "$RUNNER_TEMP/bundle-report.txt" 2>&1
+          npm run --silent bench:bundle:compare -- \
+            --skip-build --markdown "$RUNNER_TEMP/bundle-report.md" \
+            > "$RUNNER_TEMP/bundle-log.txt" 2>&1
           echo "status=$?" >> "$GITHUB_OUTPUT"
-          cat "$RUNNER_TEMP/bundle-report.txt"
+          cat "$RUNNER_TEMP/bundle-log.txt"
           exit 0
 
       - name: Report bundle budget on the PR
@@ -119,9 +121,7 @@ jobs:
               echo "ℹ️ Some metrics exceed the committed budget baseline. This is **informational only — it does not block CI.** Review the deltas below; if the change is intended, promote them with \`npm run bench:bundle -- --write-baseline benchmarks/bundle/baseline.json\` under the pinned toolchain (see \`benchmarks/bundle/README.md\`)."
             fi
             echo
-            echo '```'
-            cat "$RUNNER_TEMP/bundle-report.txt"
-            echo '```'
+            cat "$RUNNER_TEMP/bundle-report.md"
           } > "$RUNNER_TEMP/bundle-comment.md"
           existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq "map(select(.body | contains(\"$marker\"))) | .[0].id // empty")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -79,8 +82,53 @@ jobs:
       - name: Install browser runtime
         run: npm exec -- playwright install --with-deps chromium
 
+      # Bundle/package budget is informational: it reports deltas as a PR
+      # comment but never blocks CI. Intentional changes (e.g. code-splitting)
+      # are reviewed from the comment, then promoted via --write-baseline.
       - name: Compare consumer bundles and package budget
-        run: npm run bench:bundle:compare
+        id: bundle
+        run: |
+          set +e
+          npm run bench:bundle:compare > "$RUNNER_TEMP/bundle-report.txt" 2>&1
+          echo "status=$?" >> "$GITHUB_OUTPUT"
+          cat "$RUNNER_TEMP/bundle-report.txt"
+          exit 0
+
+      - name: Report bundle budget on the PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          STATUS: ${{ steps.bundle.outputs.status }}
+        run: |
+          marker="<!-- bundle-budget-report -->"
+          {
+            echo "$marker"
+            echo "## 📦 Bundle budget report"
+            echo
+            if [ "$STATUS" = "0" ]; then
+              echo "✅ No consumer bundle or package metric exceeds the committed budget baseline."
+            else
+              echo "ℹ️ Some metrics exceed the committed budget baseline. This is **informational only — it does not block CI.** Review the deltas below; if the change is intended, promote them with \`npm run bench:bundle -- --write-baseline benchmarks/bundle/baseline.json\` under the pinned toolchain (see \`benchmarks/bundle/README.md\`)."
+            fi
+            echo
+            echo '```'
+            cat "$RUNNER_TEMP/bundle-report.txt"
+            echo '```'
+          } > "$RUNNER_TEMP/bundle-comment.md"
+          existing=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq "map(select(.body | contains(\"$marker\"))) | .[0].id // empty")
+          if [ -n "$existing" ]; then
+            jq -Rs '{body: .}' < "$RUNNER_TEMP/bundle-comment.md" \
+              | gh api -X PATCH "repos/$REPO/issues/comments/$existing" --input - >/dev/null
+            echo "Updated existing bundle budget comment ($existing)."
+          else
+            jq -Rs '{body: .}' < "$RUNNER_TEMP/bundle-comment.md" \
+              | gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input - >/dev/null
+            echo "Created bundle budget comment."
+          fi
 
       - name: Create untouched baseline worktree
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Install browser runtime
         run: npm exec -- playwright install --with-deps chromium
 
+      # Build once here so the comparison output stays free of build-tool noise
+      # (the report is posted verbatim to the PR).
+      - name: Build package for bundle measurement
+        run: npm run build
+
       # Bundle/package budget is informational: it reports deltas as a PR
       # comment but never blocks CI. Intentional changes (e.g. code-splitting)
       # are reviewed from the comment, then promoted via --write-baseline.
@@ -89,7 +94,7 @@ jobs:
         id: bundle
         run: |
           set +e
-          npm run bench:bundle:compare > "$RUNNER_TEMP/bundle-report.txt" 2>&1
+          npm run --silent bench:bundle:compare -- --skip-build > "$RUNNER_TEMP/bundle-report.txt" 2>&1
           echo "status=$?" >> "$GITHUB_OUTPUT"
           cat "$RUNNER_TEMP/bundle-report.txt"
           exit 0

--- a/benchmarks/bundle/run.ts
+++ b/benchmarks/bundle/run.ts
@@ -43,6 +43,7 @@ Options:
   --baseline <file>                 Compare results with a JSON baseline
   --write-baseline <file>           Write current results as a JSON baseline
   --output <file>                   Write current results to a JSON file
+  --markdown <file>                 Write a Markdown report of the results
   --byte-tolerance-percent <value>  Allowed byte growth (default: 0)
   --package-byte-tolerance-percent <value>
                                     Allowed npm package byte growth (default: byte tolerance)
@@ -70,6 +71,7 @@ function parseArguments(argv) {
     baseline: undefined,
     writeBaseline: undefined,
     output: undefined,
+    markdown: undefined,
     byteTolerancePercent: 0,
     packageByteTolerancePercent: undefined,
     moduleTolerance: 0,
@@ -98,6 +100,9 @@ function parseArguments(argv) {
         break;
       case "--output":
         options.output = nextValue();
+        break;
+      case "--markdown":
+        options.markdown = nextValue();
         break;
       case "--byte-tolerance-percent":
         options.byteTolerancePercent = parseNumberOption(
@@ -432,6 +437,47 @@ function printResults(results) {
   }
 }
 
+function formatMarkdown(results, regressions, compared: boolean): string {
+  const header =
+    "| Fixture | Mode | Raw | Gzip | Brotli | Init gzip | Async gzip | Modules | Lucide | Chunks |";
+  const alignment =
+    "| :-- | :-- | --: | --: | --: | --: | --: | --: | --: | --: |";
+  const rows: string[] = [];
+  for (const [fixtureName, modes] of Object.entries(results.bundles)) {
+    for (const [modeName, measurement] of Object.entries(modes)) {
+      rows.push(
+        `| ${fixtureName} | ${modeName} | ${formatBytes(measurement.bytes.raw)} | ${formatBytes(measurement.bytes.gzip)} | ${formatBytes(measurement.bytes.brotli)} | ${formatBytes(measurement.delivery.initial.bytes.gzip)} | ${formatBytes(measurement.delivery.async.bytes.gzip)} | ${measurement.modules.total} | ${measurement.modules.byPackage["lucide-react"] ?? 0} | ${measurement.chunks} |`,
+      );
+    }
+  }
+
+  const summary = [
+    `**CSS:** ${formatBytes(results.assets.styles.raw)} raw / ${formatBytes(results.assets.styles.gzip)} gzip / ${formatBytes(results.assets.styles.brotli)} brotli`,
+  ];
+  if (results.package) {
+    summary.push(
+      `**Package:** ${formatBytes(results.package.packedBytes)} packed / ${formatBytes(results.package.unpackedBytes)} unpacked / ${results.package.files} files`,
+    );
+  }
+
+  const sections = [header, alignment, ...rows, "", summary.join("  \n")];
+  if (compared && regressions.length > 0) {
+    sections.push(
+      "",
+      `**${regressions.length} metric(s) over the committed budget baseline:**`,
+      ...regressions.map((regression) => `- ${regression}`),
+    );
+  }
+  return `${sections.join("\n")}\n`;
+}
+
+function writeMarkdown(targetPath, results, regressions, compared) {
+  const resolvedPath = path.resolve(REPOSITORY_ROOT, targetPath);
+  mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  writeFileSync(resolvedPath, formatMarkdown(results, regressions, compared));
+  console.log(`Wrote ${path.relative(REPOSITORY_ROOT, resolvedPath)}`);
+}
+
 function allowedByteValue(baseline, tolerancePercent) {
   return Math.floor(baseline * (1 + tolerancePercent / 100));
 }
@@ -678,9 +724,10 @@ async function main() {
   if (options.output) writeJson(options.output, results);
   if (options.writeBaseline) writeJson(options.writeBaseline, results);
 
+  let regressions: string[] = [];
   if (options.baseline) {
     const baseline = readJson(options.baseline);
-    const regressions = compareResults(results, baseline, options);
+    regressions = compareResults(results, baseline, options);
     if (regressions.length > 0) {
       console.error(`\n${regressions.length} bundle benchmark regression(s):`);
       for (const regression of regressions) console.error(`- ${regression}`);
@@ -688,6 +735,15 @@ async function main() {
     } else {
       console.log("\nBundle benchmark comparison passed.");
     }
+  }
+
+  if (options.markdown) {
+    writeMarkdown(
+      options.markdown,
+      results,
+      regressions,
+      Boolean(options.baseline),
+    );
   }
 }
 

--- a/benchmarks/bundle/run.ts
+++ b/benchmarks/bundle/run.ts
@@ -437,15 +437,91 @@ function printResults(results) {
   }
 }
 
-function formatMarkdown(results, regressions, compared: boolean): string {
-  const header =
-    "| Fixture | Mode | Raw | Gzip | Brotli | Init gzip | Async gzip | Modules | Lucide | Chunks |";
-  const alignment =
-    "| :-- | :-- | --: | --: | --: | --: | --: | --: | --: | --: |";
+// Metrics tracked in the "Changes vs baseline" section, evaluated per fixture x mode.
+// Total gzip is intentionally omitted: it equals init gzip + async gzip, so tracking
+// the eager/deferred split instead avoids a redundant (always-identical) row.
+const TRACKED_METRICS = [
+  { label: "init gzip", unit: "bytes", get: (m) => m.delivery.initial.bytes.gzip },
+  { label: "async gzip", unit: "bytes", get: (m) => m.delivery.async.bytes.gzip },
+  { label: "chunks", unit: "count", get: (m) => m.chunks },
+  { label: "lucide modules", unit: "count", get: (m) => m.modules.byPackage["lucide-react"] ?? 0 },
+];
+
+// Byte deltas below this are immaterial (compression jitter / trivial drift) and are
+// suppressed so the report highlights real movement. Count deltas are always shown.
+const MATERIAL_BYTE_DELTA = 256;
+
+function formatMetricValue(value, unit) {
+  return unit === "count" ? String(value) : formatBytes(value);
+}
+
+// A colored delta cell: 🔴 for a metric that grew, 🟢 for one that shrank. Returns null
+// when unchanged, or when a byte delta is below the materiality floor.
+function formatDelta(before, after, unit) {
+  const diff = after - before;
+  if (diff === 0) return null;
+  if (unit === "bytes" && Math.abs(diff) < MATERIAL_BYTE_DELTA) return null;
+  const magnitude = formatMetricValue(Math.abs(diff), unit);
+  return diff > 0 ? `🔴 +${magnitude}` : `🟢 -${magnitude}`;
+}
+
+function changeRows(results, baseline): string[] {
   const rows: string[] = [];
   for (const [fixtureName, modes] of Object.entries(results.bundles)) {
     for (const [modeName, measurement] of Object.entries(modes)) {
-      rows.push(
+      const baselineMeasurement = baseline.bundles?.[fixtureName]?.[modeName];
+      for (const metric of TRACKED_METRICS) {
+        const after = metric.get(measurement);
+        const before = baselineMeasurement ? metric.get(baselineMeasurement) : 0;
+        const delta = formatDelta(before, after, metric.unit);
+        if (delta) {
+          rows.push(
+            `| ${fixtureName} | ${modeName} | ${metric.label} | ${formatMetricValue(before, metric.unit)} | ${formatMetricValue(after, metric.unit)} | ${delta} |`,
+          );
+        }
+      }
+    }
+  }
+
+  // Package + CSS live outside the per-fixture bundles.
+  const extras: Array<[string, string, number, number]> = [];
+  if (results.package && baseline.package) {
+    extras.push(["Package", "packed", baseline.package.packedBytes, results.package.packedBytes]);
+  }
+  extras.push(["CSS", "gzip", baseline.assets?.styles?.gzip ?? 0, results.assets.styles.gzip]);
+  for (const [name, label, before, after] of extras) {
+    const delta = formatDelta(before, after, "bytes");
+    if (delta) {
+      rows.push(`| ${name} | — | ${label} | ${formatBytes(before)} | ${formatBytes(after)} | ${delta} |`);
+    }
+  }
+  return rows;
+}
+
+function formatMarkdown(results, baseline): string {
+  const parts: string[] = [];
+
+  if (baseline) {
+    const rows = changeRows(results, baseline);
+    parts.push("### Changes vs baseline", "");
+    if (rows.length > 0) {
+      parts.push(
+        `_🔴 grew · 🟢 shrank — measured against the committed \`baseline.json\`. Byte deltas under ${formatBytes(MATERIAL_BYTE_DELTA)} B are hidden._`,
+        "",
+        "| Fixture | Mode | Metric | Before | After | Δ |",
+        "| :-- | :-- | :-- | --: | --: | :-- |",
+        ...rows,
+      );
+    } else {
+      parts.push("No tracked metric changed versus the committed `baseline.json`.");
+    }
+    parts.push("");
+  }
+
+  const snapshotRows: string[] = [];
+  for (const [fixtureName, modes] of Object.entries(results.bundles)) {
+    for (const [modeName, measurement] of Object.entries(modes)) {
+      snapshotRows.push(
         `| ${fixtureName} | ${modeName} | ${formatBytes(measurement.bytes.raw)} | ${formatBytes(measurement.bytes.gzip)} | ${formatBytes(measurement.bytes.brotli)} | ${formatBytes(measurement.delivery.initial.bytes.gzip)} | ${formatBytes(measurement.delivery.async.bytes.gzip)} | ${measurement.modules.total} | ${measurement.modules.byPackage["lucide-react"] ?? 0} | ${measurement.chunks} |`,
       );
     }
@@ -460,21 +536,24 @@ function formatMarkdown(results, regressions, compared: boolean): string {
     );
   }
 
-  const sections = [header, alignment, ...rows, "", summary.join("  \n")];
-  if (compared && regressions.length > 0) {
-    sections.push(
-      "",
-      `**${regressions.length} metric(s) over the committed budget baseline:**`,
-      ...regressions.map((regression) => `- ${regression}`),
-    );
-  }
-  return `${sections.join("\n")}\n`;
+  parts.push(
+    "<details>",
+    `<summary>Full snapshot (${snapshotRows.length} measurements)</summary>`,
+    "",
+    "| Fixture | Mode | Raw | Gzip | Brotli | Init gzip | Async gzip | Modules | Lucide | Chunks |",
+    "| :-- | :-- | --: | --: | --: | --: | --: | --: | --: | --: |",
+    ...snapshotRows,
+    "",
+    summary.join("  \n"),
+    "</details>",
+  );
+  return `${parts.join("\n")}\n`;
 }
 
-function writeMarkdown(targetPath, results, regressions, compared) {
+function writeMarkdown(targetPath, results, baseline) {
   const resolvedPath = path.resolve(REPOSITORY_ROOT, targetPath);
   mkdirSync(path.dirname(resolvedPath), { recursive: true });
-  writeFileSync(resolvedPath, formatMarkdown(results, regressions, compared));
+  writeFileSync(resolvedPath, formatMarkdown(results, baseline));
   console.log(`Wrote ${path.relative(REPOSITORY_ROOT, resolvedPath)}`);
 }
 
@@ -724,10 +803,10 @@ async function main() {
   if (options.output) writeJson(options.output, results);
   if (options.writeBaseline) writeJson(options.writeBaseline, results);
 
-  let regressions: string[] = [];
+  let baseline;
   if (options.baseline) {
-    const baseline = readJson(options.baseline);
-    regressions = compareResults(results, baseline, options);
+    baseline = readJson(options.baseline);
+    const regressions = compareResults(results, baseline, options);
     if (regressions.length > 0) {
       console.error(`\n${regressions.length} bundle benchmark regression(s):`);
       for (const regression of regressions) console.error(`- ${regression}`);
@@ -738,12 +817,7 @@ async function main() {
   }
 
   if (options.markdown) {
-    writeMarkdown(
-      options.markdown,
-      results,
-      regressions,
-      Boolean(options.baseline),
-    );
+    writeMarkdown(options.markdown, results, baseline);
   }
 }
 


### PR DESCRIPTION
## What

Turns the consumer-bundle / package budget gate from a **hard blocker** into an **informational PR comment**.

Today, `bench:bundle:compare` fails the job if any metric exceeds `benchmarks/bundle/baseline.json`. That's correct for catching accidental bloat, but it also blocks *intentional* changes — e.g. code-splitting a dependency into an async chunk — until the baseline is regenerated under the pinned toolchain. (That's exactly what happened on #53.)

## Change

- The comparison still runs, but its output is captured and the step always succeeds — **it no longer fails CI**.
- A sticky PR comment (`<!-- bundle-budget-report -->`) reports the result: ✅ when nothing exceeds budget, or ℹ️ with the list of over-budget metrics and a reminder to promote them via `--write-baseline` if intended.
- Adds `pull-requests: write` to the job so it can post the comment; wraps the comment step in `continue-on-error` so it can never block either.
- **The strict browser-parity gate is unchanged and still blocks** — visual regressions remain hard failures.

## Rationale

Bundle size is a review signal, not a correctness gate. Making it a comment keeps the information visible on every PR without the friction of a baseline-regeneration dance for deliberate changes. Real build breakage is still caught by the blocking `Validate package` job (`npm run build`, type-check, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)