### PR TITLE
fix(canvas): stable will-change on mobile — stop gesture-toggled layer thrash (pan/zoom flashing)

### DIFF
--- a/src/components/canvas/canvas.tsx
+++ b/src/components/canvas/canvas.tsx
@@ -784,10 +784,17 @@ const Canvas: FC<Props> = ({
               x,
               y,
               scale,
-              willChange:
-                mode !== "high" && (animationStage < 2 || isPanning)
-                  ? "transform"
-                  : "auto",
+              // Keep the compositing hint STABLE on non-desktop modes. This
+              // used to toggle per gesture (set on drag start, dropped on drag
+              // end — and dropped at pinch start, since the two-pointer branch
+              // clears isPanning), which forced Chromium to promote/demote the
+              // whole scene layer and re-rasterize it on every flip: visible
+              // flashing while dragging/zooming on mobile Chromium (Brave/
+              // Chrome; Firefox layerizes differently and never showed it).
+              // A pinch also ran entirely un-promoted, re-rasterizing the full
+              // scene on every scale change. One persistent layer costs some
+              // GPU memory but never thrashes.
+              willChange: mode !== "high" ? "transform" : "auto",
             }}
           >
             {/* Canvas Background - customizable or default */}


### PR DESCRIPTION
## Problem

On phones (Chromium: Chrome/Brave; Firefox unaffected), dragging or pinch-zooming the canvas produces visible flashing.

## Root cause

The scene `motion.div`'s `will-change` toggled per gesture on non-`high` performance modes:

- drag start → `"transform"` (layer **promoted**, full scene re-raster)
- drag end → `"auto"` (layer **demoted**, another re-raster)
- **pinch start → `"auto"`** — the two-pointer branch sets `isPanning(false)`, so the entire pinch ran *un-promoted*, re-rasterizing the whole scene on every `scale.set()`

Chromium re-rasters the giant scene layer on every promote/demote flip; on phone GPUs the async raster races the compositor → flash. Desktop (`high` mode) never sets the hint (Chromium's own heuristics keep the actively-transforming layer stable) and Firefox layerizes differently — matching the observed "mobile Chromium only".

## Fix

Keep the hint stable on non-`high` modes: `willChange: mode !== "high" ? "transform" : "auto"`. One persistent composited layer; zero churn. Desktop behavior unchanged.

## Verification

CDP gesture probe (drag → pinch-out → pinch-in → drag via `Input.synthesize*Gesture`) against Android-emulator Chrome, sampling computed `will-change` every frame:

| | will-change transitions | gesture behavior | inter-frame delta p95 |
|---|---|---|---|
| before | 2–4 per sequence | ok | 11.3 |
| after | **0** | ok (translate/scale verified per gesture) | **8.0** |

The visual flash itself doesn't reproduce under emulation (real-device raster timing; the emulator compositor blocks until tiles are ready) — confirm on a real phone after release, but the thrash mechanism is eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)