### PR TITLE
feat(perf): capability-based performance tiers — assume capable by default

### DIFF
--- a/src/contexts/PerformanceContext.tsx
+++ b/src/contexts/PerformanceContext.tsx
@@ -1,6 +1,11 @@
 import React, { createContext, useContext, useEffect, useState, type ReactNode } from "react";
 import useWindowDimensions from "../hooks/useWindowDimensions";
-import { isIOS, isMobile, prefersReducedMotion } from "../utils/performance";
+import {
+    detectPerformanceMode,
+    isIOS,
+    isMobile,
+    prefersReducedMotion,
+} from "../utils/performance";
 
 export type PerformanceMode = "high" | "medium" | "low";
 
@@ -54,21 +59,17 @@ export const PerformanceProvider: React.FC<PerformanceProviderProps> = ({ childr
         const isMobileDevice = isMobile();
         const reducedMotion = prefersReducedMotion();
 
-        let mode: PerformanceMode = "high";
-
-        // Determine performance mode based on device and screen size
-        if (isIOSDevice || reducedMotion || width < 768) {
-            mode = "low";
-        } else if (isMobileDevice || width < 1024) {
-            mode = "medium";
-        }
+        // Capability-based tier (see detectPerformanceMode): device memory /
+        // core count, assuming "high" when signals are absent. Form factor is
+        // not capability — width and mobile user agents no longer downgrade.
+        const mode = detectPerformanceMode();
 
         setConfig({
             mode,
             isIOS: isIOSDevice,
             isMobile: isMobileDevice,
             prefersReducedMotion: reducedMotion,
-            // Use simpler shadows on iOS and low-end devices for better performance
+            // Use simpler shadows on low-end devices for better performance
             enableComplexShadows: mode !== "low",
         });
     }, [width]);

--- a/src/hooks/usePerformanceMode.ts
+++ b/src/hooks/usePerformanceMode.ts
@@ -1,5 +1,10 @@
 import { useState, useEffect } from "react";
-import { isIOS, isMobile, prefersReducedMotion } from "../utils/performance";
+import {
+  detectPerformanceMode,
+  isIOS,
+  isMobile,
+  prefersReducedMotion,
+} from "../utils/performance";
 import useWindowDimensions from "./useWindowDimensions";
 
 export type PerformanceMode = "high" | "medium" | "low";
@@ -20,17 +25,15 @@ const createDefaultConfig = (): PerformanceConfig => ({
   enableComplexShadows: true,
 });
 
-const detectPerformanceConfig = (width: number): PerformanceConfig => {
+// Tiering is capability-based (see detectPerformanceMode): device memory and
+// core count, assuming "high" when the signals are absent. The width argument
+// is kept for API compatibility but no longer influences the tier — a narrow
+// window is not a slow device.
+const detectPerformanceConfig = (_width: number): PerformanceConfig => {
   const isIOSDevice = isIOS();
   const isMobileDevice = isMobile();
   const reducedMotion = prefersReducedMotion();
-
-  let mode: PerformanceMode = "high";
-  if (isIOSDevice || reducedMotion || width < 768) {
-    mode = "low";
-  } else if (isMobileDevice || width < 1024) {
-    mode = "medium";
-  }
+  const mode = detectPerformanceMode();
 
   return {
     mode,

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -26,6 +26,66 @@ export const prefersReducedMotion = (): boolean => {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 };
 
+export type PerformanceModeValue = "high" | "medium" | "low";
+
+// Manual override for testing and as a user escape hatch:
+// ?canvasPerf=high|medium|low or localStorage["canvas-perf-mode"].
+const readPerformanceOverride = (): PerformanceModeValue | null => {
+  try {
+    const fromQuery = new URLSearchParams(window.location.search).get(
+      "canvasPerf",
+    );
+    const value =
+      fromQuery ?? window.localStorage.getItem("canvas-perf-mode");
+    return value === "high" || value === "medium" || value === "low"
+      ? value
+      : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Capability-based performance tier detection.
+ *
+ * Philosophy: assume a device is CAPABLE unless it presents hard evidence of
+ * being low-end. Modern phones (recent iPhones, flagship Androids) run the
+ * full experience at 60fps; only genuinely memory/CPU-starved devices need
+ * the reduced tiers. Form factor is not capability: screen width and mobile
+ * user agents say nothing about GPU/CPU power and are deliberately NOT used.
+ *
+ * Signals, strongest first:
+ * - navigator.deviceMemory (Chromium only; GiB, capped at 8): <=2 GiB is a
+ *   budget device (low), <=4 GiB is older mid-range (medium).
+ * - navigator.hardwareConcurrency: weak on Android (budget chips still report
+ *   8 cores), but <=3 cores is credible low-end evidence anywhere.
+ * - Safari/Firefox expose neither meaningfully -> assume high. iPhones in
+ *   particular are uniformly capable; the old iOS->low rule punished the
+ *   best devices.
+ * - prefers-reduced-motion -> low (most conservative presentation).
+ */
+export const detectPerformanceMode = (): PerformanceModeValue => {
+  if (typeof window === "undefined") return "high";
+
+  const override = readPerformanceOverride();
+  if (override) return override;
+
+  if (prefersReducedMotion()) return "low";
+
+  const memory = (navigator as Navigator & { deviceMemory?: number })
+    .deviceMemory;
+  if (memory !== undefined) {
+    if (memory <= 2) return "low";
+    if (memory <= 4) return "medium";
+    return "high";
+  }
+
+  const cores = navigator.hardwareConcurrency;
+  if (typeof cores === "number" && cores > 0 && cores <= 3) return "medium";
+
+  return "high";
+};
+
 // Get optimized will-change value based on state
 export const getWillChange = (
   isAnimating: boolean,


### PR DESCRIPTION
Performance mode was inferred from form factor: iOS or width<768 -> low,
mobile UA or width<1024 -> medium. That punished the best devices — a new
iPhone got the most degraded experience and every flagship Android was
"medium" — while saying nothing about actual capability.

Replace it with capability signals, defaulting to "high" unless the device
presents hard low-end evidence:

- navigator.deviceMemory (Chromium; GiB, capped at 8): <=2 -> low,
  <=4 -> medium, else high.
- navigator.hardwareConcurrency: <=3 cores -> medium (weak signal on
  Android where budget chips still report 8, credible anywhere else).
- Safari/Firefox expose neither -> assume high (iPhones are uniformly
  capable; the old iOS->low rule was backwards).
- prefers-reduced-motion still forces low.
- Manual override for testing / escape hatch: ?canvasPerf=high|medium|low
  or localStorage["canvas-perf-mode"].

Detection now lives once in utils/performance.ts (detectPerformanceMode)
and both the PerformanceProvider context and usePerformanceModeForWidth use
it; the width parameter remains for API compatibility but no longer affects
the tier — a narrow window is not a slow device.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
